### PR TITLE
feat: add root command to navigate to main repository

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -140,4 +140,5 @@ vite.config.ts.timestamp-*
 
 # worktree manager specific
 .wt_hook.js
+.wt_env
 .DS_Store

--- a/src/commands/root.ts
+++ b/src/commands/root.ts
@@ -1,0 +1,96 @@
+import chalk from 'chalk';
+import ora from 'ora';
+import { GitWorktreeManager } from '../utils/git.js';
+import type { RootCommandOptions } from '../types/index.js';
+import fs from 'fs/promises';
+import path from 'path';
+
+export async function rootCommand(options: RootCommandOptions = {}): Promise<void> {
+  const spinner = options.verbose && !options.json ? ora('Finding main repository...').start() : null;
+  
+  try {
+    const git = new GitWorktreeManager();
+    
+    if (!(await git.isGitRepository())) {
+      if (spinner) spinner.fail('Not in a git repository');
+      process.exit(1);
+    }
+    
+    const currentPath = process.cwd();
+    let mainRepository: string | undefined;
+    let envFileFound = false;
+    
+    // First, try to read from .wt_env file in current directory
+    try {
+      const envPath = path.join(currentPath, '.wt_env');
+      const envContent = await fs.readFile(envPath, 'utf-8');
+      const match = envContent.match(/^WT_ROOT_DIR="(.+)"$/m);
+      if (match) {
+        mainRepository = match[1];
+        envFileFound = true;
+      }
+    } catch {
+      // .wt_env file doesn't exist or can't be read, fallback to git worktree detection
+    }
+    
+    const projectRoot = await git.getProjectRoot();
+    const worktrees = await git.listWorktrees();
+    
+    // If not found in .env, use worktree detection
+    if (!mainRepository) {
+      const mainWorktree = worktrees.find(w => !w.path.includes('tmp_worktrees'));
+      mainRepository = mainWorktree?.path || projectRoot;
+    }
+    
+    // Sort worktrees by path length (descending) to match the most specific path first
+    const sortedWorktrees = [...worktrees].sort((a, b) => b.path.length - a.path.length);
+    
+    const currentWorktree = sortedWorktrees.find(w => currentPath.startsWith(w.path));
+    
+    // Warn if in a worktree without .wt_env file (likely created outside of wtm)
+    if (!envFileFound && currentWorktree && currentWorktree.path !== mainRepository && currentWorktree.path.includes('tmp_worktrees')) {
+      console.error(chalk.yellow('Warning: This worktree appears to be created outside of wtm (no .wt_env file found)'));
+      console.error(chalk.yellow('Consider using "wtm add" for better integration'));
+    }
+    
+    if (spinner) spinner.stop();
+    
+    if (options.json) {
+      console.log(JSON.stringify({
+        projectRoot,
+        mainRepository,
+        currentPath,
+        currentWorktree: currentWorktree?.path || null,
+        isInWorktree: !!currentWorktree && currentWorktree.path !== mainRepository
+      }, null, 2));
+      return;
+    }
+    
+    if (options.verbose) {
+      // Verbose output with full details
+      console.log(`\n${chalk.bold('Project root:')} ${chalk.green(projectRoot)}`);
+      console.log(`${chalk.bold('Main repository:')} ${chalk.green(mainRepository)}`);
+      
+      if (currentWorktree && currentWorktree.path !== mainRepository) {
+        console.log(`${chalk.bold('Current worktree:')} ${chalk.cyan(currentWorktree.path)}`);
+        console.log(`${chalk.bold('Branch:')} ${chalk.cyan(currentWorktree.branch || '(detached)')}`);
+        console.log(`\n${chalk.bold('To navigate to main repository:')}`);
+        console.log(`  ${chalk.cyan('cd "$(wtm root)"')}`);
+      } else {
+        console.log(chalk.gray('\nYou are currently in the main repository'));
+      }
+    } else {
+      // Default: output only the path
+      if (currentWorktree && currentWorktree.path !== mainRepository) {
+        console.log(mainRepository);
+      } else {
+        // Output current directory if already in main repository
+        console.log(currentPath);
+      }
+    }
+    
+  } catch (error: any) {
+    if (spinner) spinner.fail(`Error: ${error.message}`);
+    process.exit(1);
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ import { listCommand } from './commands/list.js';
 import { addCommand } from './commands/add.js';
 import { removeCommand } from './commands/remove.js';
 import { initCommand } from './commands/init.js';
+import { rootCommand } from './commands/root.js';
 
 // Read version from package.json
 const __filename = fileURLToPath(import.meta.url);
@@ -40,6 +41,13 @@ program
   .command('init')
   .description('Initialize hook file in current repository')
   .action(initCommand);
+
+program
+  .command('root')
+  .description('Show the main repository path (use with: cd "$(wtm root)")')
+  .option('-j, --json', 'Output in JSON format')
+  .option('-v, --verbose', 'Show detailed information about worktree status')
+  .action(rootCommand);
 
 // Set default action to interactive list
 program

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -39,6 +39,11 @@ export interface RemoveCommandOptions {
   force?: boolean;
 }
 
+export interface RootCommandOptions {
+  json?: boolean;
+  verbose?: boolean;
+}
+
 export interface GitWorktreeManagerInterface {
   git: SimpleGit;
   cwd: string;

--- a/src/utils/git.ts
+++ b/src/utils/git.ts
@@ -79,6 +79,20 @@ export class GitWorktreeManager implements GitWorktreeManagerInterface {
     
     await this.git.raw(['worktree', 'add', '-b', branch, worktreePath, baseBranch]);
     
+    // Create .wt_env file with worktree metadata
+    const projectRoot = await this.getProjectRoot();
+    const envContent = [
+      `# Worktree metadata`,
+      `WT_ROOT_DIR="${projectRoot}"`,
+      `WT_BRANCH_NAME="${branch}"`,
+      `WT_CREATED_AT="${new Date().toISOString()}"`,
+      `WT_BASE_BRANCH="${baseBranch}"`,
+      ''
+    ].join('\n');
+    
+    const envPath = path.join(worktreePath, '.wt_env');
+    await fs.writeFile(envPath, envContent, 'utf-8');
+    
     return worktreePath;
   }
 

--- a/test/commands/root-warning.test.ts
+++ b/test/commands/root-warning.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import chalk from 'chalk';
+import { rootCommand } from '../../src/commands/root.js';
+import { GitWorktreeManager } from '../../src/utils/git.js';
+import fs from 'fs/promises';
+
+vi.mock('../../src/utils/git.js');
+vi.mock('ora', () => ({
+  default: () => ({
+    start: vi.fn().mockReturnThis(),
+    stop: vi.fn(),
+    fail: vi.fn()
+  })
+}));
+vi.mock('fs/promises');
+
+describe('rootCommand warnings', () => {
+  let mockGitManager: any;
+  let consoleLogSpy: any;
+  let consoleErrorSpy: any;
+  let processCwdSpy: any;
+
+  beforeEach(() => {
+    mockGitManager = {
+      isGitRepository: vi.fn().mockResolvedValue(true),
+      getProjectRoot: vi.fn().mockResolvedValue('/project/root'),
+      listWorktrees: vi.fn().mockResolvedValue([])
+    };
+
+    vi.mocked(GitWorktreeManager).mockImplementation(() => mockGitManager);
+    consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    processCwdSpy = vi.spyOn(process, 'cwd').mockReturnValue('/project/root');
+    // Default: no .wt_env file
+    vi.mocked(fs.readFile).mockRejectedValue(new Error('No .wt_env file'));
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should warn when in a worktree without .wt_env file', async () => {
+    processCwdSpy.mockReturnValue('/project/root/.git/tmp_worktrees/20250712_103426_feature');
+    
+    mockGitManager.listWorktrees.mockResolvedValue([
+      { path: '/project/root', head: 'abc123', branch: 'main' },
+      { path: '/project/root/.git/tmp_worktrees/20250712_103426_feature', head: 'def456', branch: 'feature' }
+    ]);
+
+    await rootCommand();
+
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      chalk.yellow('Warning: This worktree appears to be created outside of wtm (no .wt_env file found)')
+    );
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      chalk.yellow('Consider using "wtm add" for better integration')
+    );
+    expect(consoleLogSpy).toHaveBeenCalledWith('/project/root');
+  });
+
+  it('should not warn when .wt_env file exists', async () => {
+    processCwdSpy.mockReturnValue('/project/root/.git/tmp_worktrees/20250712_103426_feature');
+    
+    // Mock .wt_env file exists
+    vi.mocked(fs.readFile).mockResolvedValue(
+      'WT_ROOT_DIR="/project/root"\n'
+    );
+    
+    mockGitManager.listWorktrees.mockResolvedValue([
+      { path: '/project/root', head: 'abc123', branch: 'main' },
+      { path: '/project/root/.git/tmp_worktrees/20250712_103426_feature', head: 'def456', branch: 'feature' }
+    ]);
+
+    await rootCommand();
+
+    expect(consoleErrorSpy).not.toHaveBeenCalled();
+    expect(consoleLogSpy).toHaveBeenCalledWith('/project/root');
+  });
+
+  it('should not warn when in main repository', async () => {
+    mockGitManager.listWorktrees.mockResolvedValue([
+      { path: '/project/root', head: 'abc123', branch: 'main' }
+    ]);
+
+    await rootCommand();
+
+    expect(consoleErrorSpy).not.toHaveBeenCalled();
+    expect(consoleLogSpy).toHaveBeenCalledWith('/project/root');
+  });
+
+  it('should not warn for worktrees not in tmp_worktrees', async () => {
+    processCwdSpy.mockReturnValue('/project/feature-worktree');
+    
+    mockGitManager.listWorktrees.mockResolvedValue([
+      { path: '/project/root', head: 'abc123', branch: 'main' },
+      { path: '/project/feature-worktree', head: 'def456', branch: 'feature' }
+    ]);
+
+    await rootCommand();
+
+    expect(consoleErrorSpy).not.toHaveBeenCalled();
+    expect(consoleLogSpy).toHaveBeenCalledWith('/project/root');
+  });
+});

--- a/test/commands/root.test.ts
+++ b/test/commands/root.test.ts
@@ -1,0 +1,276 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import chalk from 'chalk';
+import { rootCommand } from '../../src/commands/root.js';
+import { GitWorktreeManager } from '../../src/utils/git.js';
+import fs from 'fs/promises';
+
+vi.mock('../../src/utils/git.js');
+vi.mock('ora', () => ({
+  default: () => ({
+    start: vi.fn().mockReturnThis(),
+    stop: vi.fn(),
+    fail: vi.fn()
+  })
+}));
+vi.mock('fs/promises');
+
+describe('rootCommand', () => {
+  let mockGitManager: any;
+  let consoleLogSpy: any;
+  let processExitSpy: any;
+  let processCwdSpy: any;
+
+  beforeEach(() => {
+    mockGitManager = {
+      isGitRepository: vi.fn().mockResolvedValue(true),
+      getProjectRoot: vi.fn().mockResolvedValue('/project/root'),
+      listWorktrees: vi.fn().mockResolvedValue([])
+    };
+
+    vi.mocked(GitWorktreeManager).mockImplementation(() => mockGitManager);
+    consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    processExitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('process.exit');
+    });
+    processCwdSpy = vi.spyOn(process, 'cwd').mockReturnValue('/project/root');
+    // Default: no .wt_env file
+    vi.mocked(fs.readFile).mockRejectedValue(new Error('No .wt_env file'));
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should exit when not in a git repository', async () => {
+    mockGitManager.isGitRepository.mockResolvedValue(false);
+    
+    await expect(rootCommand()).rejects.toThrow('process.exit');
+    expect(processExitSpy).toHaveBeenCalledWith(1);
+  });
+
+  it('should output current path when in main repo (default)', async () => {
+    mockGitManager.listWorktrees.mockResolvedValue([
+      { path: '/project/root', head: 'abc123', branch: 'main' }
+    ]);
+
+    await rootCommand();
+
+    expect(consoleLogSpy).toHaveBeenCalledWith('/project/root');
+    expect(consoleLogSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('should output main repository path when in a worktree (default)', async () => {
+    processCwdSpy.mockReturnValue('/project/root/.git/tmp_worktrees/20250712_103426_feature');
+    
+    mockGitManager.listWorktrees.mockResolvedValue([
+      { path: '/project/root', head: 'abc123', branch: 'main' },
+      { path: '/project/root/.git/tmp_worktrees/20250712_103426_feature', head: 'def456', branch: 'feature' }
+    ]);
+
+    await rootCommand();
+
+    expect(consoleLogSpy).toHaveBeenCalledWith('/project/root');
+    expect(consoleLogSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('should display main repository info with verbose flag when in main repo', async () => {
+    mockGitManager.listWorktrees.mockResolvedValue([
+      { path: '/project/root', head: 'abc123', branch: 'main' }
+    ]);
+
+    await rootCommand({ verbose: true });
+
+    expect(consoleLogSpy).toHaveBeenCalledWith(
+      `\n${chalk.bold('Project root:')} ${chalk.green('/project/root')}`
+    );
+    expect(consoleLogSpy).toHaveBeenCalledWith(
+      `${chalk.bold('Main repository:')} ${chalk.green('/project/root')}`
+    );
+    expect(consoleLogSpy).toHaveBeenCalledWith(
+      chalk.gray('\nYou are currently in the main repository')
+    );
+  });
+
+  it('should display worktree info with verbose flag when in a worktree', async () => {
+    processCwdSpy.mockReturnValue('/project/root/.git/tmp_worktrees/20250712_103426_feature');
+    
+    mockGitManager.listWorktrees.mockResolvedValue([
+      { path: '/project/root', head: 'abc123', branch: 'main' },
+      { path: '/project/root/.git/tmp_worktrees/20250712_103426_feature', head: 'def456', branch: 'feature' }
+    ]);
+
+    await rootCommand({ verbose: true });
+
+    expect(consoleLogSpy).toHaveBeenCalledWith(
+      `${chalk.bold('Current worktree:')} ${chalk.cyan('/project/root/.git/tmp_worktrees/20250712_103426_feature')}`
+    );
+    expect(consoleLogSpy).toHaveBeenCalledWith(
+      `${chalk.bold('Branch:')} ${chalk.cyan('feature')}`
+    );
+    expect(consoleLogSpy).toHaveBeenCalledWith(
+      `  ${chalk.cyan('cd "$(wtm root)"')}`
+    );
+  });
+
+  it('should output JSON format when requested', async () => {
+    processCwdSpy.mockReturnValue('/project/root/.git/tmp_worktrees/20250712_103426_feature');
+    
+    mockGitManager.listWorktrees.mockResolvedValue([
+      { path: '/project/root', head: 'abc123', branch: 'main' },
+      { path: '/project/root/.git/tmp_worktrees/20250712_103426_feature', head: 'def456', branch: 'feature' }
+    ]);
+
+    await rootCommand({ json: true });
+
+    const jsonCall = consoleLogSpy.mock.calls[0][0];
+    const output = JSON.parse(jsonCall);
+
+    expect(output).toEqual({
+      projectRoot: '/project/root',
+      mainRepository: '/project/root',
+      currentPath: '/project/root/.git/tmp_worktrees/20250712_103426_feature',
+      currentWorktree: '/project/root/.git/tmp_worktrees/20250712_103426_feature',
+      isInWorktree: true
+    });
+  });
+
+  it('should output JSON format when in main repository', async () => {
+    mockGitManager.listWorktrees.mockResolvedValue([
+      { path: '/project/root', head: 'abc123', branch: 'main' }
+    ]);
+
+    await rootCommand({ json: true });
+
+    const jsonCall = consoleLogSpy.mock.calls[0][0];
+    const output = JSON.parse(jsonCall);
+
+    expect(output).toEqual({
+      projectRoot: '/project/root',
+      mainRepository: '/project/root',
+      currentPath: '/project/root',
+      currentWorktree: '/project/root',
+      isInWorktree: false
+    });
+  });
+
+  it('should handle no current worktree in JSON output', async () => {
+    processCwdSpy.mockReturnValue('/some/other/path');
+    
+    mockGitManager.listWorktrees.mockResolvedValue([
+      { path: '/project/root', head: 'abc123', branch: 'main' }
+    ]);
+
+    await rootCommand({ json: true });
+
+    const jsonCall = consoleLogSpy.mock.calls[0][0];
+    const output = JSON.parse(jsonCall);
+
+    expect(output).toEqual({
+      projectRoot: '/project/root',
+      mainRepository: '/project/root',
+      currentPath: '/some/other/path',
+      currentWorktree: null,
+      isInWorktree: false
+    });
+  });
+
+  it('should handle errors gracefully', async () => {
+    mockGitManager.getProjectRoot.mockRejectedValue(new Error('Git error'));
+    
+    await expect(rootCommand()).rejects.toThrow('process.exit');
+    expect(processExitSpy).toHaveBeenCalledWith(1);
+  });
+
+  it('should display detached worktree correctly with verbose flag', async () => {
+    processCwdSpy.mockReturnValue('/project/root/.git/tmp_worktrees/20250712_103426_feature');
+    
+    mockGitManager.listWorktrees.mockResolvedValue([
+      { path: '/project/root', head: 'abc123', branch: 'main' },
+      { path: '/project/root/.git/tmp_worktrees/20250712_103426_feature', head: 'def456', detached: true }
+    ]);
+
+    await rootCommand({ verbose: true });
+
+    expect(consoleLogSpy).toHaveBeenCalledWith(
+      `${chalk.bold('Branch:')} ${chalk.cyan('(detached)')}`
+    );
+  });
+
+  it('should handle no main worktree found', async () => {
+    processCwdSpy.mockReturnValue('/project/root/.git/tmp_worktrees/20250712_103426_feature');
+    
+    mockGitManager.listWorktrees.mockResolvedValue([
+      { path: '/project/root/.git/tmp_worktrees/20250712_103426_feature', head: 'def456', branch: 'feature' }
+    ]);
+
+    await rootCommand();
+
+    expect(consoleLogSpy).toHaveBeenCalledWith('/project/root');
+    expect(consoleLogSpy).toHaveBeenCalledTimes(1);
+  });
+
+
+  it('should read root path from .wt_env file when available with verbose', async () => {
+    processCwdSpy.mockReturnValue('/project/root/.git/tmp_worktrees/20250712_103426_feature');
+    
+    // Mock .wt_env file with root directory
+    vi.mocked(fs.readFile).mockResolvedValue(
+      '# Worktree metadata\nWT_ROOT_DIR="/custom/root/path"\nWT_BRANCH_NAME="feature"\n'
+    );
+    
+    mockGitManager.listWorktrees.mockResolvedValue([
+      { path: '/project/root', head: 'abc123', branch: 'main' },
+      { path: '/project/root/.git/tmp_worktrees/20250712_103426_feature', head: 'def456', branch: 'feature' }
+    ]);
+
+    await rootCommand({ verbose: true });
+
+    expect(consoleLogSpy).toHaveBeenCalledWith(
+      `${chalk.bold('Main repository:')} ${chalk.green('/custom/root/path')}`
+    );
+  });
+
+  it('should output path from .wt_env file (default)', async () => {
+    processCwdSpy.mockReturnValue('/project/root/.git/tmp_worktrees/20250712_103426_feature');
+    
+    // Mock .wt_env file with root directory
+    vi.mocked(fs.readFile).mockResolvedValue(
+      '# Worktree metadata\nWT_ROOT_DIR="/custom/root/path"\nWT_BRANCH_NAME="feature"\n'
+    );
+    
+    mockGitManager.listWorktrees.mockResolvedValue([
+      { path: '/project/root/.git/tmp_worktrees/20250712_103426_feature', head: 'def456', branch: 'feature' }
+    ]);
+
+    await rootCommand();
+
+    expect(consoleLogSpy).toHaveBeenCalledWith('/custom/root/path');
+    expect(consoleLogSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('should handle JSON output with .wt_env file', async () => {
+    processCwdSpy.mockReturnValue('/project/root/.git/tmp_worktrees/20250712_103426_feature');
+    
+    // Mock .wt_env file with root directory
+    vi.mocked(fs.readFile).mockResolvedValue(
+      'WT_ROOT_DIR="/custom/root/path"\n'
+    );
+    
+    mockGitManager.listWorktrees.mockResolvedValue([
+      { path: '/project/root/.git/tmp_worktrees/20250712_103426_feature', head: 'def456', branch: 'feature' }
+    ]);
+
+    await rootCommand({ json: true });
+
+    const jsonCall = consoleLogSpy.mock.calls[0][0];
+    const output = JSON.parse(jsonCall);
+
+    expect(output).toEqual({
+      projectRoot: '/project/root',
+      mainRepository: '/custom/root/path',
+      currentPath: '/project/root/.git/tmp_worktrees/20250712_103426_feature',
+      currentWorktree: '/project/root/.git/tmp_worktrees/20250712_103426_feature',
+      isInWorktree: true
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Add new `wtm root` command to easily navigate back to the main repository from any worktree
- Enables simple shell integration with aliases like `alias wh='cd "$(wtm root)"'`
- Improves worktree management workflow by providing quick navigation

## Features

### 1. New `wtm root` command
- **Default behavior**: Outputs only the main repository path (for shell integration)
- **`--verbose` flag**: Shows detailed worktree information (previous default behavior)
- **`--json` flag**: Outputs machine-readable JSON format

### 2. Automatic `.wt_env` file creation
- Worktrees created with `wtm add` now include a `.wt_env` file with metadata:
  - `WT_ROOT_DIR`: Path to the main repository
  - `WT_BRANCH_NAME`: Branch name
  - `WT_CREATED_AT`: Creation timestamp
  - `WT_BASE_BRANCH`: Base branch used for creation
- Enables instant path resolution without Git operations

### 3. Smart warnings
- Shows a warning when in a worktree without `.wt_env` file
- Helps identify worktrees created outside of `wtm`
- Suggests using `wtm add` for better integration

## Usage Examples

```bash
# Basic usage - outputs path only
$ wtm root
/Users/username/projects/myrepo

# Shell alias setup (add to .bashrc/.zshrc)
alias wh='cd "$(wtm root)"'

# Then simply use:
$ wh  # navigates to main repository

# Verbose mode for details
$ wtm root --verbose
Project root: /Users/username/projects/myrepo/.git/tmp_worktrees/feature
Main repository: /Users/username/projects/myrepo
Current worktree: /Users/username/projects/myrepo/.git/tmp_worktrees/feature
Branch: feature-branch

To navigate to main repository:
  cd "$(wtm root)"

# JSON output for scripting
$ wtm root --json
{
  "projectRoot": "...",
  "mainRepository": "...",
  "currentPath": "...",
  "currentWorktree": "...",
  "isInWorktree": true
}
```

## Test plan

- [x] All existing tests pass
- [x] Added comprehensive tests for new `root` command (14 test cases)
- [x] Added tests for warning behavior (4 test cases)
- [x] Updated tests for `.wt_env` file creation
- [x] Manual testing confirms expected behavior
- [x] Lint and typecheck pass