### PR TITLE
feat: enable external library support in worktree hooks

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,6 +68,9 @@ pnpm start  # Run tsx watch mode for rapid development
    - Default hook copies `.env`, `.env.local`, and `.claude` files
    - Hook files are git-ignored (included in `.gitignore`)
    - Exit codes: 0 = success, non-zero = failure with proper error reporting
+   - **Library Support**: Hooks can use libraries installed in the parent project (e.g., `zx`, `glob`)
+     - The parent project's `node_modules` is automatically added to `NODE_PATH`
+     - Simply import and use: `import { $ } from 'zx'` or `import { glob } from 'glob'`
 
 5. **Interactive UI Components** (`src/components/`)
    - `InteractiveWorktreeSelector.tsx`: Main TUI component using ink (React for CLIs)


### PR DESCRIPTION
## Summary
- Enable hooks to use external libraries (e.g., zx, glob) installed in the parent project
- Configure NODE_PATH to include parent project's node_modules during hook execution
- Provide examples and documentation for advanced hook workflows

## Test plan
- [ ] Run `wtm init` to generate a new hook file with examples
- [ ] Install a library like `zx` in the parent project: `pnpm add -D zx`
- [ ] Uncomment the zx example in `.wt_hook.js`
- [ ] Run `wtm add <branch>` and verify the hook can import and use zx
- [ ] Verify existing hooks without external libraries continue to work